### PR TITLE
Added support for Cypress 10 E2E testing

### DIFF
--- a/cypress/support/puppeteer.js
+++ b/cypress/support/puppeteer.js
@@ -44,6 +44,8 @@ module.exports = {
         mainWindow = page;
       } else if (page.url().includes('extension')) {
         metamaskWindow = page;
+      } else if (page.url().includes('e2e')) {
+        metamaskWindow = page;
       }
     }
     return true;

--- a/cypress/support/puppeteer.js
+++ b/cypress/support/puppeteer.js
@@ -42,9 +42,9 @@ module.exports = {
         mainWindow = page;
       } else if (page.url().includes('tests')) {
         mainWindow = page;
-      } else if (page.url().includes('extension')) {
-        metamaskWindow = page;
       } else if (page.url().includes('e2e')) {
+        mainWindow = page;
+      } else if (page.url().includes('extension')) {
         metamaskWindow = page;
       }
     }


### PR DESCRIPTION
Cypress 10 have E2E testing mode which uses the `e2e` path in the url (unlike Cypress 9 that has integration). 