### PR TITLE
allow duplicate metamask setups

### DIFF
--- a/cypress/support/metamask.js
+++ b/cypress/support/metamask.js
@@ -628,6 +628,12 @@ module.exports = {
       (await puppeteer.metamaskWindow().$(unlockPageElements.unlockPage)) ===
       null
     ) {
+
+      if( (await puppeteer.metamaskWindow().$(mainPageElements.walletOverview)) !== null)  {
+        await puppeteer.switchToCypressWindow();
+        return true;
+      }
+
       await module.exports.confirmWelcomePage();
       if (secretWordsOrPrivateKey.includes(' ')) {
         // secret words


### PR DESCRIPTION
Because of the way I'm running tests, I occasionally run setup multiple times. This adds a guard that allows the test suite to continue. 