### PR TITLE
add lock command

### DIFF
--- a/cypress/pages/metamask/main-page.js
+++ b/cypress/pages/metamask/main-page.js
@@ -18,6 +18,7 @@ const accountMenu = {
   createAccountButton: '.account-menu__item--clickable:nth-child(6)',
   importAccountButton: '.account-menu__item--clickable:nth-child(7)',
   settingsButton: '.account-menu__item--clickable:nth-child(11)',
+  lockButton: '.account-menu__lock-button',
 };
 
 const optionsMenu = {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -94,6 +94,10 @@ module.exports = (on, config) => {
       const notificationPage = await puppeteer.switchToMetamaskNotification();
       return notificationPage;
     },
+    lockMetamask: async () => {
+      const locked = await metamask.lock();
+      return locked;
+    },
     unlockMetamask: async password => {
       const unlocked = await metamask.unlock(password);
       return unlocked;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -135,6 +135,10 @@ Cypress.Commands.add('allowMetamaskToAddAndSwitchNetwork', () => {
   return cy.task('allowMetamaskToAddAndSwitchNetwork');
 });
 
+Cypress.Commands.add('lockMetamask', () => {
+  return cy.task('lockMetamask');
+});
+
 Cypress.Commands.add('unlockMetamask', (password = 'Tester@1234') => {
   return cy.task('unlockMetamask', password);
 });

--- a/cypress/support/metamask.js
+++ b/cypress/support/metamask.js
@@ -66,6 +66,12 @@ module.exports = {
     }
     return true;
   },
+  lock: async () => {
+    await module.exports.fixBlankPage();
+    await puppeteer.waitAndClick(mainPageElements.accountMenu.button);
+    await puppeteer.waitAndClick(mainPageElements.accountMenu.lockButton);
+    return true;
+  },
   unlock: async password => {
     await module.exports.fixBlankPage();
     await puppeteer.waitAndType(unlockPageElements.passwordInput, password);


### PR DESCRIPTION
adds lockMetamask call,  the page selector needs to be updated for the most recent version of metamask but works with the previous one. How do you usually handle that? I'm using a slightly older version because the very latest setup seems broken last week when I checked.