### PR TITLE
add simple transaction confirm

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -187,6 +187,10 @@ module.exports = (on, config) => {
       const accepted = await metamask.acceptAccess(allAccounts);
       return accepted;
     },
+    simpleTxnConfirm: async () => {
+      const confirmed = await metamask.simpleTxnConfirm();
+      return confirmed;
+    },
     confirmMetamaskTransaction: async gasConfig => {
       const confirmed = await metamask.confirmTransaction(gasConfig);
       return confirmed;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -107,6 +107,10 @@ Cypress.Commands.add('acceptMetamaskAccess', allAccounts => {
   return cy.task('acceptMetamaskAccess', allAccounts);
 });
 
+Cypress.Commands.add('simpleTxnConfirm', () => {
+  return cy.task('simpleTxnConfirm');
+});
+
 Cypress.Commands.add('confirmMetamaskTransaction', gasConfig => {
   return cy.task('confirmMetamaskTransaction', gasConfig);
 });

--- a/cypress/support/metamask.js
+++ b/cypress/support/metamask.js
@@ -475,6 +475,13 @@ module.exports = {
     await puppeteer.metamaskWindow().waitForTimeout(3000);
     return true;
   },
+  simpleTxnConfirm: async () => {
+    await puppeteer.metamaskWindow().waitForTimeout(1000);
+    const notificationPage = await puppeteer.switchToMetamaskNotification();
+    await puppeteer.waitAndClick(confirmPageElements.confirmButton, notificationPage);
+    await puppeteer.metamaskWindow().waitForTimeout(3000);
+    return true;
+  },
   confirmTransaction: async gasConfig => {
     const isKovanTestnet = getNetwork().networkName === 'kovan';
     // todo: remove waitForTimeout below after improving switchToMetamaskNotification


### PR DESCRIPTION
This allows for a simple transaction confirmation. I don't know if I was just overlooking other functionality, but the added logic in the other confirmation was  blocking my progress. Perhaps there is a better name or perhaps this is unnecessary for others, but anyone else needing just a simplistic confirm, this unblocks. 